### PR TITLE
Improve return types; add PHPStan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 /composer.lock export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/phpstan.neon.dist export-ignore
 /phpunit.xml.dist export-ignore
 /README.md export-ignore
 /src/Fixtures/ export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,3 +45,6 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose --testdox --coverage-text
+
+      - name: Execute phpstan
+        run: vendor/bin/phpstan analyse --no-progress

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /coverage
+/phpstan.neon
 /.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "php": "~8.0.0 || ~8.1.0 || ~7.4.0"
     },
     "require-dev": {
+        "phpstan/phpstan": "^1.3",
         "phpunit/phpunit": "^9.5"
     },
     "license": "MIT",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5256b455ec3875c4d3047128605383b",
+    "content-hash": "f6c53785fd685cab7e5ca5b621d242c1",
     "packages": [],
     "packages-dev": [
         {
@@ -527,6 +527,70 @@
                 "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
             "time": "2021-12-08T12:19:24+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "151a51f6149855785fbd883e79768c0abc96b75f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/151a51f6149855785fbd883e79768c0abc96b75f",
+                "reference": "151a51f6149855785fbd883e79768c0abc96b75f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/1.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-07T09:49:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2106,7 +2170,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "~8.0.0 || ~8.1.0 || ~7.4.0"
+    },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+  level: 9
+  paths:
+    - src
+  excludePaths:
+    - src/*Test.php
+    - src/Fixtures

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -27,6 +27,9 @@ class Construct
         $this->type = $type;
     }
 
+    /**
+     * @return class-string
+     */
     public function name(): string
     {
         return $this->name;
@@ -37,6 +40,9 @@ class Construct
         return $this->type;
     }
 
+    /**
+     * @return class-string
+     */
     public function __toString(): string
     {
         return $this->name;

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -10,12 +10,17 @@ use function in_array;
 
 class Construct
 {
+    /** @var class-string */
     private string $name;
 
+    /** @var 'trait'|'class'|'enum'|'interface' */
     private string $type;
 
     /**
      * @internal
+     *
+     * @param class-string $name
+     * @param 'trait'|'class'|'enum'|'interface' $type
      */
     public function __construct(string $name, string $type)
     {
@@ -35,6 +40,9 @@ class Construct
         return $this->name;
     }
 
+    /**
+     * @return 'trait'|'class'|'enum'|'interface'
+     */
     public function type(): string
     {
         return $this->type;

--- a/src/ConstructFinder.php
+++ b/src/ConstructFinder.php
@@ -203,7 +203,7 @@ class ConstructFinder
 
     public static function locatedIn(string ...$directory): self
     {
-        return new static($directory);
+        return new self($directory);
     }
 
     /**
@@ -235,10 +235,10 @@ class ConstructFinder
             }
 
             if ($token[0] === T_NAMESPACE) {
-                $namespace = static::collectNamespace($index + 1, $tokens);
+                $namespace = self::collectNamespace($index + 1, $tokens);
             }
 
-            if (array_key_exists($token[0], $interestingTokens) === false || static::isNew($index - 1, $tokens)) {
+            if (array_key_exists($token[0], $interestingTokens) === false || self::isNew($index - 1, $tokens)) {
                 continue;
             }
 

--- a/src/ConstructFinder.php
+++ b/src/ConstructFinder.php
@@ -193,7 +193,7 @@ class ConstructFinder
 
             $realPath = $file->getRealPath();
 
-            if (substr($realPath, -4) !== '.php') {
+            if ($realPath === false || substr($realPath, -4) !== '.php') {
                 continue;
             }
 

--- a/src/ConstructFinder.php
+++ b/src/ConstructFinder.php
@@ -72,6 +72,9 @@ class ConstructFinder
         return array_values($constructs);
     }
 
+    /**
+     * @return class-string[]
+     */
     public function findAllNames(): array
     {
         return $this->convertConstructsToStrings($this->findAll());
@@ -79,7 +82,7 @@ class ConstructFinder
 
     /**
      * @param Construct[] $constructs
-     * @return string[]
+     * @return class-string[]
      */
     private function convertConstructsToStrings(array $constructs): array
     {
@@ -110,6 +113,9 @@ class ConstructFinder
         return $this->findOfType('class');
     }
 
+    /**
+     * @return class-string[]
+     */
     public function findClassNames(): array
     {
         return $this->convertConstructsToStrings($this->findClasses());
@@ -123,6 +129,9 @@ class ConstructFinder
         return $this->findOfType('enum');
     }
 
+    /**
+     * @return class-string[]
+     */
     public function findEnumNames(): array
     {
         return $this->convertConstructsToStrings($this->findEnums());
@@ -136,16 +145,25 @@ class ConstructFinder
         return $this->findOfType('interface');
     }
 
+    /**
+     * @return class-string[]
+     */
     public function findInterfaceNames(): array
     {
         return $this->convertConstructsToStrings($this->findInterfaces());
     }
 
+    /**
+     * @return Construct[]
+     */
     public function findTraits(): array
     {
         return $this->findOfType('trait');
     }
 
+    /**
+     * @return class-string[]
+     */
     public function findTraitNames(): array
     {
         return $this->convertConstructsToStrings($this->findTraits());

--- a/src/ConstructFinder.php
+++ b/src/ConstructFinder.php
@@ -40,6 +40,9 @@ use const TOKEN_PARSE;
 
 class ConstructFinder
 {
+    /**
+     * @var string[]
+     */
     private array $locations;
 
     /**
@@ -47,6 +50,9 @@ class ConstructFinder
      */
     private array $excludes = [];
 
+    /**
+     * @param string[] $locations
+     */
     public function __construct(array $locations)
     {
         $this->locations = $locations;
@@ -96,6 +102,7 @@ class ConstructFinder
     }
 
     /**
+     * @param 'trait'|'class'|'enum'|'interface' $type
      * @return Construct[]
      */
     public function findOfType(string $type): array
@@ -169,6 +176,9 @@ class ConstructFinder
         return $this->convertConstructsToStrings($this->findTraits());
     }
 
+    /**
+     * @return Generator<string>
+     */
     private function locatePathsIn(string $directory): Generator
     {
         $iterator = new RecursiveIteratorIterator(
@@ -196,6 +206,9 @@ class ConstructFinder
         return new static($directory);
     }
 
+    /**
+     * @return Construct[]
+     */
     private static function findConstructsInPath(string $path): array
     {
         $source = file_get_contents($path) ?: '';
@@ -238,6 +251,9 @@ class ConstructFinder
         return $classes;
     }
 
+    /**
+     * @param array<int, array<int, int|string>|string> $tokens
+     */
     private static function collectNamespace(int $index, array $tokens): string
     {
         $token = $tokens[$index] ?? '';
@@ -270,6 +286,9 @@ class ConstructFinder
         return implode('', $parts);
     }
 
+    /**
+     * @param array<int, array<int, int|string>|string> $tokens
+     */
     private static function isNew(int $index, array $tokens): bool
     {
         $token = $tokens[$index] ?? '';
@@ -298,6 +317,9 @@ class ConstructFinder
         return $patterns;
     }
 
+    /**
+     * @return Generator<string>
+     */
     private function listAllFiles(): Generator
     {
         foreach ($this->locations as $location) {
@@ -305,6 +327,11 @@ class ConstructFinder
         }
     }
 
+    /**
+     * @param Generator<string> $listing
+     *
+     * @return Generator<string>
+     */
     private function processExcludes(Generator $listing): Generator
     {
         foreach ($listing as $path) {
@@ -319,6 +346,11 @@ class ConstructFinder
         }
     }
 
+    /**
+     * @param Generator<string> $listing
+     *
+     * @return Generator<Construct>
+     */
     private function collectConstructs(Generator $listing): Generator
     {
         foreach ($listing as $path) {

--- a/src/ConstructFinder.php
+++ b/src/ConstructFinder.php
@@ -245,6 +245,7 @@ class ConstructFinder
             $classToken = $tokens[$index + 1];
             $type = $interestingTokens[$token[0]];
             $name = trim("$namespace\\$classToken[1]", '\\');
+            // @phpstan-ignore-next-line since we know $name is a class-string
             $classes[] = new Construct($name, $type);
         }
 

--- a/src/ConstructFinder.php
+++ b/src/ConstructFinder.php
@@ -75,7 +75,7 @@ class ConstructFinder
 
         usort($constructs, fn(Construct $a, Construct $b) => $a->name() <=> $b->name());
 
-        return array_values($constructs);
+        return $constructs;
     }
 
     /**


### PR DESCRIPTION
The first commit is the most important for consumers who are using static analyzers.  All others simply add PHPStan to the CI pipeline and fix detected issues.