### PR TITLE
Ignore readonly anonymous classes

### DIFF
--- a/src/Fixtures/no-constructs.php
+++ b/src/Fixtures/no-constructs.php
@@ -11,4 +11,8 @@ namespace Something {
     use League\ConstructFinder\Fixtures\SomeInterface;
 
     new class implements SomeInterface {};
+
+    if (PHP_VERSION_ID > 80300) {
+        new readonly class () implements SomeInterface {}; // PHP 8.3+
+    }
 }


### PR DESCRIPTION
An anonymous class written as `new readonly class ()` should not be detected as a valid Construct.